### PR TITLE
Start and End GCode Settings

### DIFF
--- a/OpenCNCPilot/App.config
+++ b/OpenCNCPilot/App.config
@@ -167,6 +167,12 @@ G92Z0;</value>
    <setting name="ViewPortPos" serializeAs="String">
     <value>50;-150;250;-50;150;-250</value>
    </setting>
+   <setting name="GCodeStart" serializeAs="String">
+    <value>G90 G91.1 G21 G17</value>
+   </setting>
+   <setting name="GCodeEnd" serializeAs="String">
+    <value />
+   </setting>
   </OpenCNCPilot.Properties.Settings>
 	</userSettings>
 	<runtime>

--- a/OpenCNCPilot/GCode/GCodeFile.cs
+++ b/OpenCNCPilot/GCode/GCodeFile.cs
@@ -194,7 +194,7 @@ namespace OpenCNCPilot.GCode
 
 		public List<string> GetGCode()
 		{
-			List<string> GCode = new List<string>(Toolpath.Count + 1) { "G90 G91.1 G21 G17" };
+			List<string> GCode = new List<string>(Toolpath.Count + 1) { Settings.Default.GCodeStart }; // Start GCode
 
 			NumberFormatInfo nfi = new NumberFormatInfo();
 			nfi.NumberDecimalSeparator = ".";   //prevent problems with international versions of windows (eg Germany would write 25.4 as 25,4 which is not compatible with standard GCode)
@@ -314,7 +314,9 @@ namespace OpenCNCPilot.GCode
 				}
 			}
 
-			return GCode;
+            GCode.Add(Settings.Default.GCodeEnd); // End GCode
+
+            return GCode;
 		}
 
 		public GCodeFile Split(double length)

--- a/OpenCNCPilot/GCode/GCodeFile.cs
+++ b/OpenCNCPilot/GCode/GCodeFile.cs
@@ -194,7 +194,7 @@ namespace OpenCNCPilot.GCode
 
 		public List<string> GetGCode()
 		{
-			List<string> GCode = new List<string>(Toolpath.Count + 1) { Settings.Default.GCodeStart }; // Start GCode
+			List<string> GCode = new List<string>(Toolpath.Count + 1) { Settings.Default.GCodeStart.Trim() }; // Start GCode
 
 			NumberFormatInfo nfi = new NumberFormatInfo();
 			nfi.NumberDecimalSeparator = ".";   //prevent problems with international versions of windows (eg Germany would write 25.4 as 25,4 which is not compatible with standard GCode)
@@ -314,7 +314,7 @@ namespace OpenCNCPilot.GCode
 				}
 			}
 
-            GCode.Add(Settings.Default.GCodeEnd); // End GCode
+            GCode.Add(Settings.Default.GCodeEnd.Trim()); // End GCode
 
             return GCode;
 		}

--- a/OpenCNCPilot/Properties/Settings.Designer.cs
+++ b/OpenCNCPilot/Properties/Settings.Designer.cs
@@ -646,5 +646,29 @@ namespace OpenCNCPilot.Properties {
                 this["ViewPortPos"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("G90 G91.1 G21 G17")]
+        public string GCodeStart {
+            get {
+                return ((string)(this["GCodeStart"]));
+            }
+            set {
+                this["GCodeStart"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string GCodeEnd {
+            get {
+                return ((string)(this["GCodeEnd"]));
+            }
+            set {
+                this["GCodeEnd"] = value;
+            }
+        }
     }
 }

--- a/OpenCNCPilot/Properties/Settings.settings
+++ b/OpenCNCPilot/Properties/Settings.settings
@@ -159,5 +159,11 @@ G92Z0;</Value>
     <Setting Name="ViewPortPos" Type="System.String" Scope="User">
       <Value Profile="(Default)">50;-150;250;-50;150;-250</Value>
     </Setting>
+    <Setting Name="GCodeStart" Type="System.String" Scope="User">
+      <Value Profile="(Default)">G90 G91.1 G21 G17</Value>
+    </Setting>
+    <Setting Name="GCodeEnd" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/OpenCNCPilot/SettingsWindow.xaml
+++ b/OpenCNCPilot/SettingsWindow.xaml
@@ -84,6 +84,10 @@
 				<CheckBox Content="Include Spindle 'S' Commands" HorizontalAlignment="Left" Margin="116,10,0,0" VerticalAlignment="Top" IsChecked="{util:SettingBinding GCodeIncludeSpindle}" ToolTip="Strip S[XX] from file before sending to machine if not checked"/>
 				<CheckBox Content="Include Dwell 'G4' Commands" HorizontalAlignment="Left" Margin="116,30,0,0" VerticalAlignment="Top" IsChecked="{util:SettingBinding GCodeIncludeDwell}" ToolTip="Strip G4 P[XX] from file before sending to machine if not checked"/>
 				<CheckBox Content="Include Program End (M2, M30)" HorizontalAlignment="Left" Margin="116,50,0,0" VerticalAlignment="Top" IsChecked="{util:SettingBinding GCodeIncludeMEnd}" ToolTip="Strip M2/M30 from file before sending to machine if not checked. Default is off since these commands reset offsets from G92."/>
+				<TextBox Margin="116,77,0,0" Text="{util:SettingBinding GCodeStart}" VerticalScrollBarVisibility="Visible" Height="65" Width="229" VerticalContentAlignment="Top" AcceptsReturn="True" HorizontalContentAlignment="Left"/>
+				<Label Content="Start GCode" HorizontalAlignment="Left" Margin="10,75,0,0" VerticalAlignment="Top" Width="101" HorizontalContentAlignment="Right"/>
+				<TextBox Margin="116,152,0,0" Text="{util:SettingBinding GCodeEnd}" VerticalScrollBarVisibility="Visible" Height="65" Width="229" VerticalContentAlignment="Top" AcceptsReturn="True" HorizontalContentAlignment="Left"/>
+				<Label Content="End GCode" HorizontalAlignment="Left" Margin="10,150,0,0" VerticalAlignment="Top" Width="101" HorizontalContentAlignment="Right"/>
 			</Grid>
 		</TabItem>
 	</TabControl>


### PR DESCRIPTION
My GCode sender (EASEL Inventables) does not support the original header you have hardcoded (I have to modify it all the time in notepad) so I was thinking on a way to cleanly add a way for users of the X-Carve, I think this solution is pretty clean:

![image](https://user-images.githubusercontent.com/1091420/77832561-5ddb1400-7137-11ea-873f-86b698b50f21.png)

It looks like Cura :D