### PR TITLE
Changed behaviour of height map interpolation when a point is outside the probe area

### DIFF
--- a/OpenCNCPilot/GCode/HeightMap.cs
+++ b/OpenCNCPilot/GCode/HeightMap.cs
@@ -76,8 +76,14 @@ namespace OpenCNCPilot.GCode
 
 		public double InterpolateZ(double x, double y)
 		{
-			if (x > Max.X || x < Min.X || y > Max.Y || y < Min.Y)
-				return MaxHeight;
+			if (x < Min.X)
+				x = Min.X;
+			if (x > Max.X)
+				x = Max.X;
+			if (y > Max.Y)
+				y = Max.Y;
+			if (y < Min.Y)
+				y = Min.Y;
 
 			x -= Min.X;
 			y -= Min.Y;


### PR DESCRIPTION
In one of my recent auto-leveling pcb job, I couldn't probe the whole surface of the job because of the presence of fixtures on two corners of the pcb. So I restricted the probe area to a surface that left some tracks outside of that area. During milling, these tracks haven't be milled because the tool path was too high. I saw that the Z axis was doing an abrupt change of coordinate when crossing the probing area edges.

Looking at the source code of OpenCncPilot I saw that the surface of all points outside of the probe area are considered to be at an height equal to the max probed height. This explain the jump in Z coordinates I saw when crossing the edges of the probe area.

Take as an example the following job with sample data consisting of a lot of small squares, with a probe area that don't cover the whole pcb.
![test-pattern2](https://github.com/martin2250/OpenCNCPilot/assets/3206965/96069e4f-a466-4a27-9103-097aa7a9e758)
We see that the resulting auto-leveled job has jumps on Z outside the probe area because the max probe height is used there:
![autolevel-old2](https://github.com/martin2250/OpenCNCPilot/assets/3206965/cf4b396b-2a5e-4b57-8c3d-8a874c01581f)


So my proposal with this PR is to use instead the probed height of the nearest point on the probe area edge:
![autolevel-new2](https://github.com/martin2250/OpenCNCPilot/assets/3206965/453740dc-ba91-45e3-972e-41a5cef4f6e6)
